### PR TITLE
Fix error message when 7z not available on Linux

### DIFF
--- a/cuetochd.sh
+++ b/cuetochd.sh
@@ -47,7 +47,7 @@ function Extract-Zip {
 function Extract-7z {
     #1 is 7z file with full path $2 is working folder.
     hash 7z 2>/dev/null || { echo >&2 "This requires 7z. Please install it. Debian/ubuntu: apt install p7zip-full. Redhat: yum install p7zip-full. SUSE: zypper install p7zip-full. Arch: pacman -S p7zip-full"; exit 1; }
-    7z x -o"$2" "$1"
+    7z x "$1" -o"$2"
     Route-File "$2"
 }
 
@@ -74,7 +74,7 @@ function Got-File {
         Extract-Zip "$1" "$WORKDIRECTORY"
     elif [ "$EXTLOWER" = "7z" ]; then
         Extract-7z "$1" "$WORKDIRECTORY"
-    elif [ "$EXTLOWER" = "cue"  || [ "$EXTLOWER" = "iso" ] || [ "$EXTLOWER"  = "gdi" ]; then
+    elif [ "$EXTLOWER" = "cue" ] || [ "$EXTLOWER" = "iso" ] || [ "$EXTLOWER"  = "gdi" ]; then
         chdman createcd -i "$1"  -o "$OUT/$FILENOEXT.chd" -f
         rm -rf "$WORKDIRECTORY"
     else

--- a/cuetochd.sh
+++ b/cuetochd.sh
@@ -44,6 +44,13 @@ function Extract-Zip {
     Route-File "$2"
 }
 
+function Extract-7zip {
+    #1 is 7z file with full path $2 is working folder.
+    hash 7z 2>/dev/null || { echo >&2 "This requires 7z. Please install it. Debian/ubuntu: apt install p7zip-full. Redhat: yum install p7zip-full. SUSE: zypper install p7zip-full. Arch: pacman -S p7zip-full"; exit 1; }
+    7z x -o"$2" "$1"
+    Route-File "$2"
+}
+
 function Got-Folder {
     #$1 is the folder
     ls "$1" | while read LINE
@@ -64,7 +71,9 @@ function Got-File {
     if [ "$EXTLOWER" = 'rar' ]; then
         Extract-Rar "$1" "$WORKDIRECTORY"
     elif [ "$EXTLOWER" = "zip" ]; then
-        echo "unzip"
+        Extract-Zip "$1" "$WORKDIRECTORY"
+    elif [ "$EXTLOWER" = "7z" ]; then
+        Extract-7zip "$1" "$WORKDIRECTORY"
     elif [ "$EXTLOWER" = "cue" ]; then
         chdman createcd -i "$1"  -o "$OUT/$FILENOEXT.chd" -f
         rm -rf "$WORKDIRECTORY"

--- a/readme.MD
+++ b/readme.MD
@@ -28,8 +28,8 @@ C:\src\CueToChd> .\cuetochd.ps1 -in "D:\backups\Sega CD" -out $env:TEMP
 ```
 
 ### Linux
-No binaries are included with linux. You must install unrar, mame-tools and unzip.
-Linux "only" supports rar and zip archives. I didn't test with 7z, gz, etc.
+No binaries are included with linux. You must install unrar, mame-tools, p7zip-full and unzip.
+Linux "only" supports rar, 7z and zip archives. I didn't test with tar, gz, etc.
 
 parameters:
 -i is your input file or folder. It can be a folder, .cue file or an archive. Recommended enclosing with single quotes.


### PR DESCRIPTION
Appreciate the script, way more effective than the one-liner I was manually crafting on the prompt. Thanks for making it!

Since my files were in 7z (and it was supported in the Powershell version), I added 7z support in the Linux version. I also fixed it so that zip files are also extracted, as the command wasn't being called.